### PR TITLE
Adding running migrations to our CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,7 @@ services:
 script:
   - ln -s ./docker/docker-compose.yml ./docker-compose.yml
   - docker-compose build
+  # test if we are able to setup database schema properly
+  # should catch most typical errors in migrations
+  - docker-compose run --rm web python manage.py migrate
   - docker-compose run --rm web py.test --cov=.


### PR DESCRIPTION
Adding running migrations to our CI. Should catch most migrations errors.

Now we only run `py.test` (we just create test database from models we actually have).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/enviromonitor/enviromonitorweb/29)
<!-- Reviewable:end -->
