### PR TITLE
Enable X-Forwarded-Proto header

### DIFF
--- a/EnviroMonitorWeb/settings/prod.py
+++ b/EnviroMonitorWeb/settings/prod.py
@@ -31,3 +31,5 @@ DATABASES = {
         'HOST': os.environ.get('DB_HOST')
     }
 }
+
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
Enable X-Forwarded-Proto header we are getting from our proxy to inform django request is secure or not (HTTPS/HTTP).

Details here:
https://docs.djangoproject.com/en/1.10/ref/settings/#secure-proxy-ssl-header

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/enviromonitor/enviromonitorweb/66)
<!-- Reviewable:end -->
